### PR TITLE
Navigate to Page Fix

### DIFF
--- a/matchmaking/frontend/Dockerfile
+++ b/matchmaking/frontend/Dockerfile
@@ -51,5 +51,5 @@ RUN npm run build
 # Set the working directory to /app/dist
 WORKDIR /app/dist
 
-# Start the production server with "serve" on port 7000
-CMD ["serve", "-p", "7000"]
+# Start the production server with "serve" using SPA mode, and on port 7000
+CMD ["serve", "-s", "-p", "7000"]


### PR DESCRIPTION
…g navigation to routes other than the base url.

# Summary
<!-- Please include a summary of the changes. -->

Fixed bug which was preventing refresh/navigation in production.
Previously, the web server would return a 404 if refreshing on, or navigating to, a route other than the base url. Adding the `-s` flag to the serve command puts the server in "Single Page Application mode" allows intake of traffic to routes other than the base.

[![](https://img.shields.io/badge/tickets_and_issues_this_solves-blue?style=for-the-badge)](https://hamzamohdzubair.github.io/redant/)

<!-- Please include a list of Tickets and or Issues this PR resolves. -->

- None listed.

## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] Dependency updates (may include refactoring of a dependencies functionality).
- [ ] New feature (non-breaking change which adds functionality).

## How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes. -->



## Checklist:
<!--
- I have performed a self-review of my code.
- I have commented my code, particularly in hard-to-understand areas.
- I have made necessary changes to the documentation.
- My changes generate no new warnings.
 -->

- [ ] I have read the checklist.